### PR TITLE
Добавил ChernivtsiJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@
 
 ## Черновцы
 
-- ChernivtsiJS – [@chernivtsijs](https://twitter.com/chernivtsijs), [http://chernivtsi.js.org/](http://chernivtsi.js.org/)
+- ChernivtsiJS – [@chernivtsijs](https://twitter.com/chernivtsijs), [http://chernivtsi.js.org/](http://chernivtsi.js.org/), [FB: chernivtsijs](https://www.facebook.com/chernivtsijs/)
 
 ## Ярославль
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,10 @@
 
 - ChernihivJS — [@chernihivjs](https://twitter.com/chernihivjs), [chernihivjs.org.ua](https://chernihivjs.org.ua/)
 
+## Черновцы
+
+- ChernivtsiJS – [@chernivtsijs](https://twitter.com/chernivtsijs), [http://chernivtsi.js.org/](http://chernivtsi.js.org/)
+
 ## Ярославль
 
 - Yaroslavl Frontend Meetup — [@yarfrontend](https://twitter.com/yarfrontend), [yarfrontend.ru](http://yarfrontend.ru)


### PR DESCRIPTION
ChernivtsiJS – сообщество организовано летом 2016 года. Успели провести два митапа. Языки русский, украинский.