### PR TITLE
Update kyivjs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 ## Киев
 
-- KyivJS — [@kyivjs](https://twitter.com/kyivjs), [kyivjs.org.ua](http://kyivjs.org.ua)
+- KyivJS — [@kyivjs](https://twitter.com/kyivjs), [kyivjs.org](http://kyivjs.org)
 
 ## Кировоград
 


### PR DESCRIPTION
We have changed the url for the site. Yeah, right now there're some issues due to github deprecating renderer we used, fixing that atm.